### PR TITLE
Postfix and dovecot logging timestamp

### DIFF
--- a/source/rc.dovecot/dovecot-log/env/LOG_SCRIPT
+++ b/source/rc.dovecot/dovecot-log/env/LOG_SCRIPT
@@ -1,2 +1,2 @@
-n4 s500000 T $LOGDIR_PATH
+n4 s500000 $LOGDIR_PATH
 # Logging script used by s6-log

--- a/source/rc.postfix/postfix-log/env/LOG_SCRIPT
+++ b/source/rc.postfix/postfix-log/env/LOG_SCRIPT
@@ -1,2 +1,2 @@
-n4 s500000 T $LOGDIR_PATH
+n4 s500000 $LOGDIR_PATH
 # Logging script used by s6-log


### PR DESCRIPTION
Both postfix and dovecot already log the date/time.

dovecot logs:

> Dec 29 09:07:10 imap-login: Info: Login: user=<belka@caraus.de>, method=CRAM-MD5, rip=1.2.3.4, lip=5.6.7.8, mpid=12345678, TLS, session=<12345678>

postfix has pretty the same format but with the hostname after the date/time.

The date/time can probably be disabled in dovecot by setting `log_timestamp` to an empty string. The default is:

```
# Prefix for each line written to log file. % codes are in strftime(3)
# format.
#log_timestamp = "%b %d %H:%M:%S "
```

I couldn't find a similar option for postfix, even logging to stdout is relative new for postfix.