### PR TITLE
Write to stdout explicitly in static-nodes

### DIFF
--- a/source/rc.udev/static-nodes/dependencies
+++ b/source/rc.udev/static-nodes/dependencies
@@ -1,1 +1,2 @@
 devtmpfs
+procfs

--- a/source/rc.udev/static-nodes/up
+++ b/source/rc.udev/static-nodes/up
@@ -2,7 +2,8 @@
 # Create static nodes in /dev #
 ###############################
 
-pipeline { kmod static-nodes -f tmpfiles }
+# /dev/stdout may not exist at this point
+pipeline { kmod static-nodes -f tmpfiles --output /proc/self/fd/1 }
 pipeline { sort -r }
 pipeline { uniq }
 pipeline { sed "s/!//" }


### PR DESCRIPTION
# Problem

- rc.udev/static-nodes doesn't create static nodes (/dev/fuse for example).
- `kmod static-nodes` doesn't produce any output after boot

# What happens

`static-nodes` doesn't have any dependencies besides `devtmpfs`. There is a good chance that `static-nodes` starts before `udev`.
`kmod static-nodes` without `--output` seems to write to `/dev/stdout`. `/dev/stdout` is a symbolic link to `/proc/self/fd/1` (process' stdout) and is created by udev. if `/dev/stdout` doesn't exist yet, `kmod static-nodes` creates a plain file `/dev/stdout`, doesn't produce any output to its real `stdout` and `rc.udev/static-nodes` fails (because `forstdin` fails without some input).
This is also the reason why `kmod static-nodes` doesn't produce any output after the booting: /dev/stdout is a plain text file and not a symbolic link to `/proc/self/fd/1`, udev doesn't override `/dev/stdout` with the correct symbolic link if the file already exists.  It can break other programs that write to `/dev/stdout`.

# Solution

Slackware's `rc.udev` doesn't have this problem since it writes to a temporary file. Writing explicitly to `/proc/self/fd/1` fixes this as well.